### PR TITLE
Declared data_root variable to hold the value of data directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ ADD config/nginx.conf /opt/etc/nginx.conf
 RUN rm /etc/nginx/sites-enabled/default
 
 # Declaring the data dir
-ENV ${data_root:-/data}
+ENV \$data_root /data
 
 # Nginx startup script
 ADD config/nginx-start.sh /opt/bin/nginx-start.sh
 RUN chmod u=rwx /opt/bin/nginx-start.sh
 
-RUN mkdir -p ${data_root}
+RUN mkdir -p \$data_root
 #VOLUME ["/data"]
-VOLUME ${data_root}
+VOLUME \$data_root
 
 # PORTS
 EXPOSE 80 8080 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,16 @@ RUN apt-get update -y && \
 ADD config/nginx.conf /opt/etc/nginx.conf
 RUN rm /etc/nginx/sites-enabled/default
 
+#Declaring the data dir
+ENV data_root /data
+
 # Nginx startup script
 ADD config/nginx-start.sh /opt/bin/nginx-start.sh
 RUN chmod u=rwx /opt/bin/nginx-start.sh
 
-RUN mkdir -p /data
-VOLUME ["/data"]
+RUN mkdir -p ${data_root}
+#VOLUME ["/data"]
+VOLUME ${data_root}
 
 # PORTS
 EXPOSE 80 8080 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update -y && \
 ADD config/nginx.conf /opt/etc/nginx.conf
 RUN rm /etc/nginx/sites-enabled/default
 
-#Declaring the data dir
-ENV data_root /data
+# Declaring the data dir
+ENV ${data_root:-/data}
 
 # Nginx startup script
 ADD config/nginx-start.sh /opt/bin/nginx-start.sh

--- a/config/nginx-start.sh
+++ b/config/nginx-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cp /opt/etc/nginx.conf /etc/nginx/nginx.conf
 
-cp /data/${NGINX_VHOSTS} /etc/nginx/sites-available/
+cp /${data_root}/${NGINX_VHOSTS} /etc/nginx/sites-available/
 ln -s /etc/nginx/sites-available/*.conf /etc/nginx/sites-enabled/
 
 sed -i "s/%fastgci-ip%/$PHP_PORT_9000_TCP_ADDR/" /etc/nginx/nginx.conf


### PR DESCRIPTION
Fixed the below issue when trying to start docker container in spira/docker-nginx 

cp: cannot stat '/data/vhosts/nginx/*.local.conf': No such file or directory
nginx: [emerg] open() "/data/logs/access.log" failed (2: No such file or directory)
